### PR TITLE
Running the linter for all ruby code

### DIFF
--- a/rails-app.sh
+++ b/rails-app.sh
@@ -55,8 +55,7 @@ if [[ ${GIT_BRANCH} != "origin/master" ]]; then
     --diff \
     --cached \
     --format html --out rubocop-${GIT_COMMIT}.html \
-    --format clang \
-    app test lib
+    --format clang
 fi
 
 bundle exec rake db:drop db:create db:schema:load


### PR DESCRIPTION
There were discrepancies between the linter on jenkins and the linter invoked by
rspec in some projects (.e.g. content-tagger). The difference is that the linter
running on jenkins was disregarding code on config/ and spec/.

This commit adds those directories to the list.
