### PR TITLE
When SCSS_LINT is "yes", run the linter

### DIFF
--- a/rails-app.sh
+++ b/rails-app.sh
@@ -52,11 +52,19 @@ bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without devel
 
 # Lint changes introduced in this branch, but not for master
 if [[ ${GIT_BRANCH} != "origin/master" ]]; then
+  echo "Running ruby linter"
   bundle exec govuk-lint-ruby \
     --diff \
     --cached \
     --format html --out rubocop-${GIT_COMMIT}.html \
     --format clang
+fi
+
+# If we can find a path to the SCSS linter, run it
+
+if [[ ${SCSS_LINT} == "yes" ]]; then
+  echo "Running SASS linter"
+  bundle exec govuk-lint-sass app/assets/stylesheets
 fi
 
 # Setup the DB


### PR DESCRIPTION
We would like to enable linting of SCSS files on `content-tagger`.

By setting SCSS_LINT to "yes" in our jenkins.sh scripts, we can run the it.

Here is an example: https://ci.dev.publishing.service.gov.uk/job/govuk_content_tagger_branches/512/console
